### PR TITLE
Unified start commands across components

### DIFF
--- a/mhs/inbound/Dockerfile
+++ b/mhs/inbound/Dockerfile
@@ -15,4 +15,4 @@ RUN pipenv install --deploy --ignore-pipfile
 
 EXPOSE 443 80
 
-ENTRYPOINT pipenv run start-inbound
+ENTRYPOINT pipenv run start

--- a/mhs/inbound/Pipfile
+++ b/mhs/inbound/Pipfile
@@ -22,4 +22,4 @@ unittests-cov = 'coverage run -m xmlrunner -o test-reports -v'
 coverage-report = 'coverage report'
 coverage-report-xml = 'coverage xml'
 coverage-report-html = 'coverage html'
-start-inbound = "python main.py"
+start = "python main.py"

--- a/mhs/outbound/Dockerfile
+++ b/mhs/outbound/Dockerfile
@@ -18,4 +18,4 @@ RUN pipenv install --deploy --ignore-pipfile
 
 EXPOSE 80
 
-ENTRYPOINT pipenv run start-outbound
+ENTRYPOINT pipenv run start

--- a/mhs/outbound/Pipfile
+++ b/mhs/outbound/Pipfile
@@ -31,4 +31,4 @@ coverage-report = 'coverage report'
 coverage-report-xml = 'coverage xml'
 coverage-report-html = 'coverage html'
 generate-openapi-docs = 'python generate_openapi.py'
-start-outbound = "python main.py"
+start = "python main.py"


### PR DESCRIPTION
This makes all components start by running `pip start` rather than a mix of commands before.

We build a thin layer on top of the official images so it makes it bit easier for us to have the same command.