### PR TITLE
Remove limit on number of outbound external attachments

### DIFF
--- a/mhs/common/mhs_common/request/request_body_schema.py
+++ b/mhs/common/mhs_common/request/request_body_schema.py
@@ -121,10 +121,7 @@ class RequestBodySchema(marshmallow.Schema):
         ExternalAttachmentSchema, many=True, missing=[],
         description='Optional external attachments to include in the Manifest '
                     'that will be sent in separate messages. Only for use '
-                    'for interactions that support sending attachments.',
-        # EIS 2.5.4.2 says that the max number of attachments is 100, including
-        # the ebXML MIME part. And there is also the HL7 payload, so 100 - 2 = 98
-        validate=marshmallow.validate.Length(max=98))
+                    'for interactions that support sending attachments.')
 
     @marshmallow.post_load
     def make_request_body(self, data, **kwargs):

--- a/mhs/outbound/outbound/request/synchronous/tests/test_handler.py
+++ b/mhs/outbound/outbound/request/synchronous/tests/test_handler.py
@@ -683,3 +683,17 @@ class TestSynchronousHandlerSyncMessage(BaseHandlerTest):
 
         self.assertEqual(response.code, 200)
         self.assertEqual(response.headers["Correlation-Id"], CORRELATION_ID)
+
+    def test_request_with_10_000_doesnt_error(self):
+        expected_response = SYNC_RESPONSE
+        result = test_utilities.awaitable((200, expected_response, None))
+
+        self.workflow.handle_outbound_message.return_value = result
+        self.config_manager.get_interaction_details.return_value = {'sync_async': False, 'workflow': WORKFLOW_NAME}
+
+        response = self.call_handler(body=json.dumps({"payload": "test",
+            "external_attachments": [{
+                "message_id": "200",
+                "description": "some description"}] * 10_000}))
+
+        self.assertEqual(response.code, 200)


### PR DESCRIPTION
The original limit appeared erroneous, and not part of the specification.

- [x] Tests

There [exists a test](https://github.com/nhsconnect/integration-adaptor-mhs/blob/474f302ae8f0bb017e12fd00920ab20ed544f8a6/mhs/outbound/outbound/request/synchronous/tests/test_handler.py#L605-L615) which covers the limit for attachments, but no similar test for `external_attachments` so I suspect that this validation code was indeed a mistake. Adding confidence to its removal.