### PR TITLE
Fix a couple of errors with build pipeline

### DIFF
--- a/component-test.Dockerfile
+++ b/component-test.Dockerfile
@@ -1,6 +1,6 @@
 # This file is used to run component tests on CI. Once the component tests don't rely on the common project, this
 # file can be moved to a sub directory.
-FROM python:3.7-slim
+FROM python:3.7-slim-bullseye
 
 RUN apt-get update
 RUN apt-get install -y build-essential libssl-dev swig pkg-config

--- a/dockers/mhs-base/inbound/Dockerfile
+++ b/dockers/mhs-base/inbound/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as base
+FROM python:3.7-slim-bullseye as base
 
 RUN apt-get update && \
     apt-get install -y build-essential libssl-dev swig pkg-config

--- a/dockers/mhs-base/outbound/Dockerfile
+++ b/dockers/mhs-base/outbound/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as base
+FROM python:3.7-slim-bullseye as base
 
 RUN apt-get update && \
     apt-get install build-essential libcurl4-openssl-dev libssl-dev -y

--- a/dockers/mhs-base/sds/Dockerfile
+++ b/dockers/mhs-base/sds/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim as base
+FROM python:3.7-slim-bullseye as base
 
 RUN apt-get update && \
     apt-get install build-essential -y

--- a/integration-tests/fake_spine/Dockerfile
+++ b/integration-tests/fake_spine/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.7-slim-bullseye
 RUN apt-get update
 RUN apt-get install build-essential git -y
 RUN mkdir -p /usr/src/app/mhs/fakespine

--- a/mhs/outbound/Pipfile
+++ b/mhs/outbound/Pipfile
@@ -14,12 +14,8 @@ tornado = "~=6.0"
 defusedxml = "~=0.6"
 mhs-common = {editable = true,path = "./../common"}
 isodate = "~=0.6"
-# Temporarily hack the pycurl dependency so that we use a binary package
-# on Windows. This hack should be removed once
-# https://github.com/pycurl/pycurl/issues/569 is fixed.
-pycurl = {version = "~=7.43",platform_system = "!= 'Windows'"}
-pycurl-windows = {file = "https://ci.appveyor.com/api/buildjobs/k46mau52pldh189m/artifacts/dist/pycurl-7.43.0.3-cp37-cp37m-win32.whl",platform_system = "== 'Windows'"}
 integration-adaptors-common = {editable = true, path = "./../../common"}
+pycurl = "~=7.43"
 
 [requires]
 python_version = "3.7"

--- a/mhs/outbound/Pipfile.lock
+++ b/mhs/outbound/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "ace019a964202632309530241143f046a471c1e6cd97fcfda8a7b6317c568cb0"
+            "sha256": "c2026f1dbc30700ee1254b8ac7739290f9526e74903c4df191daf1e4d2a0a914"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.8"
+            "python_version": "3.7"
         },
         "sources": [
             {
@@ -263,7 +263,7 @@
                 "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9",
                 "sha256:cdf6525904cc597730141d61b36f2e4b8ecc257c420fa2f4549bac2c2d0cb72f"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==0.10.0"
         },
         "lxml": {
@@ -437,14 +437,10 @@
         },
         "pycurl": {
             "hashes": [
-                "sha256:6f08330c5cf79fa8ef68b9912b9901db7ffd34b63e225dce74db56bb21deda8e"
+                "sha256:5730590be0271364a5bddd9e245c9cc0fb710c4cbacbdd95264a3122d23224ca"
             ],
-            "markers": "platform_system != 'Windows'",
-            "version": "==7.43.0.3"
-        },
-        "pycurl-windows": {
-            "file": "https://ci.appveyor.com/api/buildjobs/k46mau52pldh189m/artifacts/dist/pycurl-7.43.0.3-cp37-cp37m-win32.whl",
-            "platform_system": "== 'Windows'"
+            "index": "pypi",
+            "version": "==7.45.2"
         },
         "pymongo": {
             "hashes": [
@@ -578,7 +574,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "python-qpid-proton": {
@@ -599,7 +595,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "tornado": {
@@ -828,6 +824,7 @@
         },
         "pyyaml": {
             "hashes": [
+                "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf",
                 "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293",
                 "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b",
                 "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57",
@@ -839,26 +836,32 @@
                 "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287",
                 "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513",
                 "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0",
+                "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782",
                 "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0",
                 "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92",
                 "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f",
                 "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2",
                 "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc",
+                "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1",
                 "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c",
                 "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86",
                 "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4",
                 "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c",
                 "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34",
                 "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b",
+                "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d",
                 "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c",
                 "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb",
+                "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7",
                 "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737",
                 "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3",
                 "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d",
+                "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358",
                 "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53",
                 "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78",
                 "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803",
                 "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a",
+                "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f",
                 "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174",
                 "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"
             ],
@@ -869,7 +872,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2'",
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "unittest-xml-reporting": {

--- a/pipeline/packer/scr-web-service.json
+++ b/pipeline/packer/scr-web-service.json
@@ -11,7 +11,7 @@
   "builders": [
     {
       "type": "docker",
-      "image": "python:3.7-slim",
+      "image": "python:3.7-slim-bullseye",
       "commit": true,
       "changes": [
         "EXPOSE 80",


### PR DESCRIPTION
- Clean up a temporary pycurl workaround which is now causing problems with `pipenv` version 2023.6.26 or later.
- Pin to bullseye version of python docker image, as the newer bookworm is having problems.