### PR TITLE
NIAD-2865: Inbound messages are stored on AMQP durably

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed 
 
-Remove the SUPPORTED_FILE_TYPES environment variable. As the allowed types are fixed by the Spine External Interface 
-Specification. 
+- Remove the SUPPORTED_FILE_TYPES environment variable.
+  As the allowed types are fixed by the Spine External Interface Specification. 
+
+- Messages sent to the inbound AMQP are configured with durability enabled.
+  This should cause the broker to try its hardest to keep the message, e.g. in the event of a reboot.
+  Some brokers (e.g. RabbitMQ) will need to have the existing non-durable queue deleted before a durable version can be created.
 
 ## [1.2.8] - 2023-09-20
 

--- a/common/comms/blocking_queue_adaptor.py
+++ b/common/comms/blocking_queue_adaptor.py
@@ -1,5 +1,6 @@
 from proton import Message, Timeout
 from proton.utils import BlockingConnection
+from proton.reactor import DurableSubscription
 
 
 class BlockingQueueAdaptor(object):
@@ -19,7 +20,7 @@ class BlockingQueueAdaptor(object):
         :return: Message read from queue
         """
         connection = BlockingConnection(self.queue_url, user=self.username, password=self.password)
-        receiver = connection.create_receiver(self.queue_name)
+        receiver = connection.create_receiver(self.queue_name, options=DurableSubscription())
         message = receiver.receive(timeout=30)
         receiver.accept()
         connection.close()
@@ -31,7 +32,7 @@ class BlockingQueueAdaptor(object):
         Drain the queue to prevent test failures caused by previous failing tests not ack'ing all of their messages
         """
         connection = BlockingConnection(self.queue_url, user=self.username, password=self.password)
-        receiver = connection.create_receiver(self.queue_name)
+        receiver = connection.create_receiver(self.queue_name, options=DurableSubscription())
         try:
             while True:
                 receiver.receive(timeout=1)

--- a/common/comms/proton_queue_adaptor.py
+++ b/common/comms/proton_queue_adaptor.py
@@ -92,6 +92,7 @@ class ProtonQueueAdaptor(comms.queue_adaptor.QueueAdaptor):
                               content_type='application/json',
                               body=json.dumps(message),
                               properties=properties,
+                              durable=True,
                               ttl=self.ttl_in_seconds)
 
     async def __try_sending_to_all_in_sequence(self, message: proton.Message) -> None:

--- a/common/comms/tests/test_proton_queue_adaptor.py
+++ b/common/comms/tests/test_proton_queue_adaptor.py
@@ -208,7 +208,13 @@ class TestProtonMessagingHandler(unittest.TestCase):
             user=TEST_QUEUE_USERNAME,
             password=TEST_QUEUE_PASSWORD,
             reconnect=False)
-        mock_event.container.create_sender.assert_called_once_with(conn_mock, target=TEST_QUEUE_NAME)
+        mock_event.container.create_sender.assert_called_once_with(conn_mock, target=TEST_QUEUE_NAME, options=unittest.mock.ANY)
+
+        # Connects with the ProtonDurableSender which marks the queue as durable
+        self.assertIsInstance(
+            mock_event.container.create_sender.call_args[1]['options'],
+            comms.proton_queue_adaptor.ProtonDurableSender
+        )
 
     def test_on_start_error(self):
         """Test error condition when creating a message sender."""

--- a/integration-tests/integration_tests/integration_tests/amq/amq_message_assertor.py
+++ b/integration-tests/integration_tests/integration_tests/amq/amq_message_assertor.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import json
 import unittest
 
+from proton import Message
+
 from integration_tests.xml.hl7_xml_assertor import Hl7XmlResponseAssertor
 
 
@@ -14,7 +16,7 @@ class AMQMessageAssertor(object):
     Provides the ability to assert properties of an AMQ message
     """
 
-    def __init__(self, message):
+    def __init__(self, message: Message):
         self.message = message
         self.assertor = unittest.TestCase('__init__')
 
@@ -28,6 +30,10 @@ class AMQMessageAssertor(object):
         property_value = self.message.properties[property_name]
         self.assertor.assertEqual(property_value, expected_value, "Property of message does not equal expected value")
 
+        return self
+    
+    def assert_durable_is(self, expected_value: bool) -> AMQMessageAssertor:
+        self.assertor.assertEqual(self.message.durable, expected_value)
         return self
 
     def assert_json_content_type(self) -> AMQMessageAssertor:

--- a/integration-tests/integration_tests/integration_tests/component_tests/component_forward_reliable_message_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/component_tests/component_forward_reliable_message_pattern_tests.py
@@ -39,6 +39,7 @@ class ForwardReliablesMessagingPatternTests(unittest.TestCase):
         # Assert
         AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue()) \
             .assert_property('message-id', message_id)\
+            .assert_durable_is(True)\
             .assertor_for_hl7_xml_message()\
             .assert_element_attribute(".//ControlActEvent//code", "displayName", "GP2GP Large Message Attachment Information")
 

--- a/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_asynchronous_express_messaging_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_asynchronous_express_messaging_pattern_tests.py
@@ -57,7 +57,8 @@ class AsynchronousExpressMessagingPatternTests(TestCase):
         AssertWithRetries(retry_count=10) \
             .assert_condition_met(lambda: MhsTableStateAssertor.wait_for_inbound_response_processed(message_id))
 
-        amq_assertor = AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue())
+        amq_assertor = AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue()) \
+            .assert_durable_is(True)
         state_table_assertor = MhsTableStateAssertor(MHS_STATE_TABLE_WRAPPER.get_all_records_in_table())
 
         self.assertions.spline_reply_published_to_message_queue(amq_assertor, message_id, correlation_id)

--- a/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_asynchronous_reliable_messaging_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_asynchronous_reliable_messaging_pattern_tests.py
@@ -60,7 +60,8 @@ class AsynchronousReliableMessagingPatternTests(TestCase):
             .execute_post_expecting_success()
 
         # Assert
-        amq_assertor = AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue())
+        amq_assertor = AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue()) \
+            .assert_durable_is(True)
         self.assertions.spline_reply_published_to_message_queue(amq_assertor, message_id, correlation_id)
         hl7_xml_assertor = amq_assertor.assertor_for_hl7_xml_message()
         self._assert_gp_summary_upload_success_detail_is_present(hl7_xml_assertor)

--- a/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_asynchronous_reliable_messaging_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_asynchronous_reliable_messaging_pattern_tests.py
@@ -18,7 +18,7 @@ from integration_tests.helpers.concurrent_requests import send_messages_concurre
 from integration_tests.http.mhs_http_request_builder import MhsHttpRequestBuilder
 from integration_tests.xml.hl7_xml_assertor import Hl7XmlResponseAssertor
 
-@skipIf(datetime.now() < datetime(2023, 10, 4), "Skipped for 1 week or until failures are addressed by NIAD-2842 ")
+@skipIf(datetime.now() < datetime(2023, 10, 24), "Skipped for 1 week or until failures are addressed by NIAD-2842 ")
 class AsynchronousReliableMessagingPatternTests(TestCase):
     """
      These tests show an asynchronous reliable response from Spine via the MHS for the example message interaction of

--- a/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_forward_reliable_messaging_pattern_tests.py
+++ b/integration-tests/integration_tests/integration_tests/end_to_end_tests/int_forward_reliable_messaging_pattern_tests.py
@@ -70,6 +70,7 @@ class ForwardReliableMessagingPatternTests(TestCase):
 
         # Assert
         AMQMessageAssertor(MHS_INBOUND_QUEUE.get_next_message_on_queue()) \
+            .assert_durable_is(True) \
             .assert_property('message-id', message_id) \
             .assert_property('correlation-id', message_id) \
             .assert_json_content_type() \


### PR DESCRIPTION
## What

Messages sent to the inbound AMQP are configured with durability. This means that the broker will try its hardest to keep the message, e.g. in the event of a reboot.

## Why

These messages shouldn't be lost, as they can be part of clinically important data transfers, e.g. GP2GP

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have updated the [Changelog](CHANGELOG.md) with details of my change in the UNRELEASED section if this change will affect end users
